### PR TITLE
승수 21.03.28 장터게시판 게시물 작성 시간 1시간 내의 게시물을 크롤링하여 DB에 저장된 키워드와 비교하여 일치하면 …

### DIFF
--- a/app/src/main/java/com/cookandroid/everytimecrawler/MainActivity.java
+++ b/app/src/main/java/com/cookandroid/everytimecrawler/MainActivity.java
@@ -101,7 +101,7 @@ public class MainActivity extends AppCompatActivity {
             jump_thread.join();
             if(loadingJump) {
                 Log.e("loadingJump", String.valueOf(loadingJump));
-                intent2 = new Intent(getApplicationContext(), loading.class);
+                intent2 = new Intent(getApplicationContext(), SubActivity.class);
                 startActivity(intent2);
                 finish();
             }

--- a/app/src/main/java/com/cookandroid/everytimecrawler/SubActivity.java
+++ b/app/src/main/java/com/cookandroid/everytimecrawler/SubActivity.java
@@ -367,7 +367,7 @@ public class SubActivity extends AppCompatActivity {
                     android.util.Log.i("크롤링 인텐트로 넘어감", "Information message");
                     intent2 = new Intent(getApplicationContext(), loading.class);
                     startActivity(intent2);
-                    push();
+//                    push();
                     finish();
                     break;
 


### PR DESCRIPTION
장터게시판 게시물 작성 시간 1시간 내의 게시물을 크롤링하여 DB에 저장된 키워드와 비교하여 일치하면 푸시알림이 옴.
푸시알림을 클릭하면 에브리타임 혹은 크롬으로 게시물로 연결됨.
DB의 des가 ON이면 loading 대신 SubActivity로 화면전환되게 고침.
Crawling Service가 실행되면 cookie를 새로 갱신하는 기능 구현.
cookie는 50분마다 갱신.

추후 :
에브리타임이 없으면 마켓으로 연결
푸시 알림이 여러 개 오면 여러 번 Notification 뜨게 하기

버그 : 서비스 Destroy해도 크롤링 스레드가 꺼지지않음.